### PR TITLE
Fix SlideTracks to work better with keyboard navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import {
   Watch,
   PageNotFound,
 } from './pages'
+import { WindowWidthContextProvider } from './context/WindowWidthContext'
 import { RequireAuth, RedirectUser } from './components'
 import * as ROUTES from './constants/routes'
 
@@ -34,7 +35,14 @@ function App() {
 
         {/* Protected routes*/}
         <Route element={<RequireAuth />}>
-          <Route path={ROUTES.BROWSE} element={<Browse />} />
+          <Route
+            path={ROUTES.BROWSE}
+            element={
+              <WindowWidthContextProvider>
+                <Browse />
+              </WindowWidthContextProvider>
+            }
+          />
           <Route path={ROUTES.PROFILE} element={<Profile />} />
           <Route path={`${ROUTES.GET_THE_APP}/:id`} element={<GetTheApp />} />
           <Route path={ROUTES.SEARCH} element={<SearchPage />} />

--- a/src/components/ContentSlide.js
+++ b/src/components/ContentSlide.js
@@ -1,9 +1,10 @@
+import { memo } from 'react'
+
 import styled from 'styled-components'
 import useLargeModal from '../hooks/useLargeModal'
 import { LargeContentModal } from './'
 
 const Container = styled.div`
-  /* position: relative; */
   min-width: min(24%, 300px);
   padding: 0 0.2vw;
 
@@ -25,7 +26,7 @@ const ContentImage = styled.img`
   }
 `
 
-export default function ContentSlide({ item, isSlideOnCurrentPage }) {
+function ContentSlide({ item, isSlideOnCurrentPage }) {
   const { displayModal, handleShowModal, handleKeyDown, handleCloseModal } =
     useLargeModal()
   const imgUrl = `/images/${item.category}/${item.genre}/${item.slug}/thumb.jpg`
@@ -46,3 +47,6 @@ export default function ContentSlide({ item, isSlideOnCurrentPage }) {
     </Container>
   )
 }
+
+// memoize ContentSlide to prevent unnecessary rerenders everytime window resizes (via SlideTrack)
+export default memo(ContentSlide)

--- a/src/components/ContentSlide.js
+++ b/src/components/ContentSlide.js
@@ -25,15 +25,17 @@ const ContentImage = styled.img`
   }
 `
 
-export default function ContentSlide({ item }) {
+export default function ContentSlide({ item, isSlideOnCurrentPage }) {
   const { displayModal, handleShowModal, handleKeyDown, handleCloseModal } =
     useLargeModal()
   const imgUrl = `/images/${item.category}/${item.genre}/${item.slug}/thumb.jpg`
 
+  const tabIndex = isSlideOnCurrentPage ? '0' : '-1'
+
   return (
     <Container onClick={handleShowModal} displayModal={displayModal}>
       <ContentImage
-        tabIndex='0'
+        tabIndex={tabIndex}
         src={imgUrl}
         alt={item.title}
         onKeyDown={handleKeyDown}

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -6,14 +6,22 @@ import { ContentSlide } from '../components'
 const SlideTrackWrapper = styled.div`
   position: relative;
   overflow: hidden;
+
+  &:hover > button > i,
+  &:focus-within > button > i {
+    display: block;
+  }
 `
 
-const GoBackBox = styled.div`
+const GoBackBox = styled.button`
   position: absolute;
   width: 4%;
   top: 0;
   bottom: 0;
   z-index: 10;
+
+  color: inherit;
+  border: 0;
 
   display: flex;
   justify-content: center;
@@ -39,6 +47,10 @@ const GoForwardBox = styled(GoBackBox)`
 
 const ArrowIcon = styled.i`
   font-size: 3rem;
+
+  @media (hover: hover) {
+    display: none;
+  }
 `
 
 const Track = styled.div`

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -49,6 +49,9 @@ export default function SlideTrack({ content }) {
   const ref = useRef(null)
 
   useLayoutEffect(() => {
+    // clear state when content updates
+    dispatch({ type: 'RESET_STATE' })
+
     const totalNumSlides = content.length
     const slideWidth = ref.current.firstChild.getBoundingClientRect().width
     const slideTrackWidth = ref.current.getBoundingClientRect().width

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -52,21 +52,16 @@ export default function SlideTrack({ content }) {
     // clear state when content updates
     dispatch({ type: 'RESET_STATE' })
 
-    const totalNumSlides = content.length
+    // then setup state values based on current content & slideWidth
     const slideWidth = ref.current.firstChild.getBoundingClientRect().width
     const slideTrackWidth = ref.current.getBoundingClientRect().width
     const pageLength = Math.floor(slideTrackWidth / slideWidth)
-    const totalNumPages = Math.ceil(totalNumSlides / pageLength)
 
     dispatch({ type: 'SET_PAGE_LENGTH', payload: pageLength })
-    dispatch({ type: 'SET_TOTAL_PAGES', payload: totalNumPages })
     dispatch({ type: 'SET_ACTIVE_SLIDES' })
-    console.log('first useLayoutEffect fired')
-  }, [content, dispatch])
+  }, [dispatch])
 
   useLayoutEffect(() => {
-    console.log('2nd useLayoutEffect fired')
-
     // update trackOffset value when window resizes
     const slideWidth = ref.current.firstChild.getBoundingClientRect().width
     dispatch({ type: 'SET_TRACK_OFFSET', payload: slideWidth })
@@ -77,10 +72,7 @@ export default function SlideTrack({ content }) {
       // get width of first slide
       const slideWidth = ref.current.firstChild.getBoundingClientRect().width
       dispatch({ type: 'SET_TRACK_OFFSET', payload: slideWidth })
-      console.log('setTrackOffset fired')
     }
-
-    console.log('useEffect fired')
 
     // recalc offset everytime window resizes
     window.addEventListener('resize', setTrackOffset)
@@ -88,7 +80,8 @@ export default function SlideTrack({ content }) {
   }, [dispatch])
 
   const handleForward = () => {
-    const isLastPage = state.totalPages - 1 === state.currentPage
+    const totalNumPages = Math.ceil(content.length / state.pageLength)
+    const isLastPage = totalNumPages - 1 === state.currentPage
 
     if (isLastPage) return
 

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -27,6 +27,11 @@ const GoBackBox = styled.div`
   &:hover {
     background: rgba(20, 20, 20, 0.7);
   }
+
+  &:focus-visible {
+    outline: auto;
+    outline-offset: -1px;
+  }
 `
 const GoForwardBox = styled(GoBackBox)`
   right: 0;
@@ -45,7 +50,6 @@ const Track = styled.div`
 
 export default function SlideTrack({ content }) {
   const [state, dispatch] = useSlideTracks()
-
   const ref = useRef(null)
 
   useLayoutEffect(() => {
@@ -97,7 +101,7 @@ export default function SlideTrack({ content }) {
   }
 
   return (
-    <SlideTrackWrapper tabIndex='0'>
+    <SlideTrackWrapper>
       <GoBackBox className='go-back' tabIndex='0' onClick={handleBack}>
         <ArrowIcon className='fas fa-angle-left' />
       </GoBackBox>

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import styled from 'styled-components'
 import useSlideTracks from '../hooks/useSlideTracks'
 import { ContentSlide } from '../components'
@@ -61,21 +61,31 @@ export default function SlideTrack({ content }) {
     dispatch({ type: 'SET_PAGE_LENGTH', payload: pageLength })
     dispatch({ type: 'SET_TOTAL_PAGES', payload: totalNumPages })
     dispatch({ type: 'SET_ACTIVE_SLIDES' })
+    console.log('first useLayoutEffect fired')
   }, [content, dispatch])
 
   useLayoutEffect(() => {
+    console.log('2nd useLayoutEffect fired')
+
+    // update trackOffset value when window resizes
+    const slideWidth = ref.current.firstChild.getBoundingClientRect().width
+    dispatch({ type: 'SET_TRACK_OFFSET', payload: slideWidth })
+  }, [state.currentPage, dispatch])
+
+  useEffect(() => {
     const setTrackOffset = () => {
       // get width of first slide
       const slideWidth = ref.current.firstChild.getBoundingClientRect().width
       dispatch({ type: 'SET_TRACK_OFFSET', payload: slideWidth })
+      console.log('setTrackOffset fired')
     }
 
-    setTrackOffset()
+    console.log('useEffect fired')
 
     // recalc offset everytime window resizes
     window.addEventListener('resize', setTrackOffset)
     return () => window.removeEventListener('resize', setTrackOffset)
-  }, [state.currentPage, dispatch])
+  }, [dispatch])
 
   const handleForward = () => {
     const isLastPage = state.totalPages - 1 === state.currentPage

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -67,8 +67,7 @@ export default function SlideTrack({ content }) {
     const setTrackOffset = () => {
       // get width of first slide
       const slideWidth = ref.current.firstChild.getBoundingClientRect().width
-      dispatch({ type: 'SET_SLIDE_WIDTH', payload: slideWidth })
-      dispatch({ type: 'SET_TRACK_OFFSET' })
+      dispatch({ type: 'SET_TRACK_OFFSET', payload: slideWidth })
     }
 
     setTrackOffset()

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -43,7 +43,6 @@ const Track = styled.div`
 `
 
 export default function SlideTrack({ content }) {
-  const [firstSlide, setFirstSlide] = useState(0)
   const [pages, setPages] = useState({
     currentPage: 0,
     pageLength: 0,
@@ -83,8 +82,9 @@ export default function SlideTrack({ content }) {
       // get width of first slide
 
       const slideWidth = ref.current.firstChild.getBoundingClientRect().width
+      const pageWidth = slideWidth * pages.pageLength
 
-      const trackOffset = slideWidth * firstSlide
+      const trackOffset = pageWidth * pages.currentPage
       setTrackOffset(`-${trackOffset}px`)
     }
 
@@ -93,18 +93,38 @@ export default function SlideTrack({ content }) {
     // recalc offset everytime window resizes
     window.addEventListener('resize', calcTrackOffset)
     return () => window.removeEventListener('resize', calcTrackOffset)
-  }, [firstSlide])
+  }, [pages])
+
+  const calcNewPageSlides = (pages, increment) => {
+    const firstSlide = (pages.currentPage + increment) * pages.pageLength
+
+    return Array.from(Array(pages.pageLength)).map((item, i) => i + firstSlide)
+  }
 
   const handleForward = () => {
-    setFirstSlide((prev) => {
-      const isLastSlide = prev === content.length - 1
-      return isLastSlide ? prev : prev + 1
+    setPages((prev) => {
+      const isLastPage = prev.totalPages - 1 === prev.currentPage
+
+      if (isLastPage) return prev
+
+      return {
+        ...prev,
+        currentPage: prev.currentPage + 1,
+        slides: calcNewPageSlides(prev, 1),
+      }
     })
   }
   const handleBack = () => {
-    setFirstSlide((prev) => {
-      const isFirstSlide = prev === 0
-      return isFirstSlide ? prev : prev - 1
+    setPages((prev) => {
+      const isFirstPage = prev.currentPage === 0
+
+      if (isFirstPage) return prev
+
+      return {
+        ...prev,
+        currentPage: prev.currentPage - 1,
+        slides: calcNewPageSlides(prev, -1),
+      }
     })
   }
 

--- a/src/components/SlideTrack.js
+++ b/src/components/SlideTrack.js
@@ -1,5 +1,6 @@
-import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import styled from 'styled-components'
+import { useWindowWidthContext } from '../context/WindowWidthContext'
 import useSlideTracks from '../hooks/useSlideTracks'
 import { ContentSlide } from '../components'
 
@@ -62,6 +63,7 @@ const Track = styled.div`
 
 export default function SlideTrack({ content }) {
   const [state, dispatch] = useSlideTracks()
+  const windowWidth = useWindowWidthContext()
   const ref = useRef(null)
 
   useLayoutEffect(() => {
@@ -81,19 +83,7 @@ export default function SlideTrack({ content }) {
     // update trackOffset value when window resizes
     const slideWidth = ref.current.firstChild.getBoundingClientRect().width
     dispatch({ type: 'SET_TRACK_OFFSET', payload: slideWidth })
-  }, [state.currentPage, dispatch])
-
-  useEffect(() => {
-    const setTrackOffset = () => {
-      // get width of first slide
-      const slideWidth = ref.current.firstChild.getBoundingClientRect().width
-      dispatch({ type: 'SET_TRACK_OFFSET', payload: slideWidth })
-    }
-
-    // recalc offset everytime window resizes
-    window.addEventListener('resize', setTrackOffset)
-    return () => window.removeEventListener('resize', setTrackOffset)
-  }, [dispatch])
+  }, [windowWidth, state.currentPage, dispatch])
 
   const handleForward = () => {
     const totalNumPages = Math.ceil(content.length / state.pageLength)

--- a/src/context/WindowWidthContext.js
+++ b/src/context/WindowWidthContext.js
@@ -1,0 +1,26 @@
+import { useLayoutEffect, useState, createContext, useContext } from 'react'
+
+export const WindowWidthContext = createContext()
+
+export function WindowWidthContextProvider({ children }) {
+  const [width, setWidth] = useState(window.innerWidth)
+
+  // useLayoutEffect runs before React renders the component making it a better choice for DOM measurement than useEffect, which runs after rendering/screen painting
+  useLayoutEffect(() => {
+    const updateWidth = () => setWidth(window.innerWidth)
+
+    // updates state when screen width changes
+    window.addEventListener('resize', updateWidth)
+
+    // clean up event listener
+    return () => window.removeEventListener('resize', updateWidth)
+  }, [])
+
+  return (
+    <WindowWidthContext.Provider value={width}>
+      {children}
+    </WindowWidthContext.Provider>
+  )
+}
+
+export const useWindowWidthContext = () => useContext(WindowWidthContext)

--- a/src/hooks/useLargeModal.js
+++ b/src/hooks/useLargeModal.js
@@ -8,9 +8,12 @@ export default function useLargeModal() {
   }
 
   const handleKeyDown = (e) => {
-    if (e.key === 'Enter') {
-      setDisplayModal(true)
-    }
+    // add delay to stop Play button also being activated!
+    setTimeout(() => {
+      if (e.key === 'Enter') {
+        setDisplayModal(true)
+      }
+    }, 10)
   }
 
   const handleCloseModal = (e) => {

--- a/src/hooks/useSlideTracks.js
+++ b/src/hooks/useSlideTracks.js
@@ -15,8 +15,8 @@ const setActiveSlides = (state) => {
   return Array.from(Array(state.pageLength)).map((item, i) => i + firstSlide)
 }
 
-const setTrackOffset = (state) => {
-  const pageWidth = state.slideWidth * state.pageLength
+const setTrackOffset = (state, slideWidth) => {
+  const pageWidth = slideWidth * state.pageLength
   const trackOffset = pageWidth * state.currentPage
 
   return `-${trackOffset}px`
@@ -24,8 +24,6 @@ const setTrackOffset = (state) => {
 
 const reducer = (state, action) => {
   switch (action.type) {
-    case 'SET_SLIDE_WIDTH':
-      return { ...state, slideWidth: action.payload }
     case 'SET_CURRENT_PAGE':
       return { ...state, currentPage: action.payload }
     case 'SET_PAGE_LENGTH':
@@ -35,7 +33,7 @@ const reducer = (state, action) => {
     case 'SET_ACTIVE_SLIDES':
       return { ...state, activeSlides: setActiveSlides(state) }
     case 'SET_TRACK_OFFSET':
-      return { ...state, trackOffset: setTrackOffset(state) }
+      return { ...state, trackOffset: setTrackOffset(state, action.payload) }
     case 'RESET_STATE':
       return { ...initialState }
     default:

--- a/src/hooks/useSlideTracks.js
+++ b/src/hooks/useSlideTracks.js
@@ -1,0 +1,48 @@
+import { useReducer } from 'react'
+
+const setActiveSlides = (state) => {
+  const firstSlide = state.currentPage * state.pageLength
+
+  return Array.from(Array(state.pageLength)).map((item, i) => i + firstSlide)
+}
+
+const setTrackOffset = (state) => {
+  const pageWidth = state.slideWidth * state.pageLength
+  const trackOffset = pageWidth * state.currentPage
+
+  return `-${trackOffset}px`
+}
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'SET_SLIDE_WIDTH':
+      return { ...state, slideWidth: action.payload }
+    case 'SET_CURRENT_PAGE':
+      return { ...state, currentPage: action.payload }
+    case 'SET_PAGE_LENGTH':
+      return { ...state, pageLength: action.payload }
+    case 'SET_TOTAL_PAGES':
+      return { ...state, totalPages: action.payload }
+    case 'SET_ACTIVE_SLIDES':
+      return { ...state, activeSlides: setActiveSlides(state) }
+    case 'SET_TRACK_OFFSET':
+      return { ...state, trackOffset: setTrackOffset(state) }
+    default:
+      throw new Error(`Unhandled action type: ${action.type}`)
+  }
+}
+
+export default function useSlideTracks(
+  initialState = {
+    slideWidth: 0,
+    currentPage: 0,
+    pageLength: 0,
+    totalPages: 0,
+    activeSlides: [],
+    trackOffset: '0px',
+  }
+) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  return [state, dispatch]
+}

--- a/src/hooks/useSlideTracks.js
+++ b/src/hooks/useSlideTracks.js
@@ -1,10 +1,8 @@
 import { useReducer } from 'react'
 
 const initialState = {
-  slideWidth: 0,
   currentPage: 0,
   pageLength: 0,
-  totalPages: 0,
   activeSlides: [],
   trackOffset: '0px',
 }
@@ -28,8 +26,6 @@ const reducer = (state, action) => {
       return { ...state, currentPage: action.payload }
     case 'SET_PAGE_LENGTH':
       return { ...state, pageLength: action.payload }
-    case 'SET_TOTAL_PAGES':
-      return { ...state, totalPages: action.payload }
     case 'SET_ACTIVE_SLIDES':
       return { ...state, activeSlides: setActiveSlides(state) }
     case 'SET_TRACK_OFFSET':

--- a/src/hooks/useSlideTracks.js
+++ b/src/hooks/useSlideTracks.js
@@ -1,5 +1,14 @@
 import { useReducer } from 'react'
 
+const initialState = {
+  slideWidth: 0,
+  currentPage: 0,
+  pageLength: 0,
+  totalPages: 0,
+  activeSlides: [],
+  trackOffset: '0px',
+}
+
 const setActiveSlides = (state) => {
   const firstSlide = state.currentPage * state.pageLength
 
@@ -27,21 +36,14 @@ const reducer = (state, action) => {
       return { ...state, activeSlides: setActiveSlides(state) }
     case 'SET_TRACK_OFFSET':
       return { ...state, trackOffset: setTrackOffset(state) }
+    case 'RESET_STATE':
+      return { ...initialState }
     default:
       throw new Error(`Unhandled action type: ${action.type}`)
   }
 }
 
-export default function useSlideTracks(
-  initialState = {
-    slideWidth: 0,
-    currentPage: 0,
-    pageLength: 0,
-    totalPages: 0,
-    activeSlides: [],
-    trackOffset: '0px',
-  }
-) {
+export default function useSlideTracks() {
   const [state, dispatch] = useReducer(reducer, initialState)
 
   return [state, dispatch]

--- a/src/pages/Browse.js
+++ b/src/pages/Browse.js
@@ -1,8 +1,8 @@
-import useWindowWidth from '../hooks/useWindowWidth'
+import { useWindowWidthContext } from '../context/WindowWidthContext'
 import { BrowseMobileLayout, BrowseDesktopLayout } from '../parts'
 
 export default function Browse() {
-  const width = useWindowWidth()
+  const width = useWindowWidthContext()
 
   return <>{width < 768 ? <BrowseMobileLayout /> : <BrowseDesktopLayout />}</>
 }


### PR DESCRIPTION
Browse pages slides (desktop layout) now move in "pages" and tabIndex="-1" is conditionally added to slides that are not currently on the screen. This prevents the SlideTrack layout from breaking when you tab to a slide not yet on the screen.

And moving the slides in pages rather than one at a time is closer to how they work on NetFlix.