### PR TITLE
Fix play button on iOS

### DIFF
--- a/src/components/BrowseButtons.js
+++ b/src/components/BrowseButtons.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { colors } from '../styles/style-constants'
 
 export const PlayButton = styled.button`
   border: 0;
@@ -7,9 +8,10 @@ export const PlayButton = styled.button`
   font-weight: 700;
   padding: 8px 24px 8px 20px;
   margin-right: 1rem;
+  background-color: ${colors.playButtonWhite};
 
   &:hover {
-    background-color: rgba(255, 255, 255, 0.75);
+    background-color: ${colors.playButtonHover};
   }
 
   &:focus {
@@ -24,10 +26,10 @@ export const PlayIcon = styled.i`
 
 export const MoreInfoButton = styled(PlayButton)`
   color: white;
-  background-color: rgba(109, 109, 110, 0.7);
+  background-color: ${colors.moreInfoButtonGrey};
 
   &:hover {
-    background-color: rgba(109, 109, 110, 0.4);
+    background-color: ${colors.moreInfoButtonHover};
   }
 `
 

--- a/src/components/LargeContentModal.js
+++ b/src/components/LargeContentModal.js
@@ -120,10 +120,14 @@ const CloseButton = styled.button`
   margin-top: 1.25em;
   margin-right: 1.25em;
   line-height: 1;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `
 
 const CloseIcon = styled.i`
-  font-size: 1.3rem;
+  font-size: 1.25rem;
 `
 
 const DetailsContainer = styled.div`

--- a/src/context/WindowWidthContext.js
+++ b/src/context/WindowWidthContext.js
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState, createContext, useContext } from 'react'
 
-export const WindowWidthContext = createContext()
+const WindowWidthContext = createContext()
 
 export function WindowWidthContextProvider({ children }) {
   const [width, setWidth] = useState(window.innerWidth)

--- a/src/styles/style-constants.js
+++ b/src/styles/style-constants.js
@@ -15,6 +15,10 @@ export const colors = {
   errTextRed: 'hsl(1, 62%, 45%)', // #b92d2b
   textDarkGrey: 'hsl(0, 0%, 20%)', // #333333
   accordionGrey: 'hsl(0, 0%, 19%)',
+  playButtonWhite: 'hsl(240, 10%, 92%)', // #e9e9ed
+  playButtonHover: 'hsla(0, 0%, 100%, 0.75)',
+  moreInfoButtonGrey: 'hsla(240, 0%, 43%, 0.7)',
+  moreInfoButtonHover: 'hsla(240, 0%, 43%, 0.4)',
 }
 
 // TODO: consolidate into object???


### PR DESCRIPTION
The play button background was appearing as transparent on iOS. I've fixed it by adding a background-color property to the button rather than relying on inheritance. I've also added the button colors to the style-constants. 