### PR TITLE
Fix: mobileSearchLayout onclick

### DIFF
--- a/src/parts/SearchResultsLayoutMobile.js
+++ b/src/parts/SearchResultsLayoutMobile.js
@@ -44,7 +44,7 @@ export default function SearchResultsLayout({ searchResults }) {
           tabIndex='0'
           src={imgUrl}
           alt={show.title}
-          onClick={() => navigate(GET_THE_APP, { state: show })}
+          onClick={() => navigate(`${GET_THE_APP}/${show.id}`)}
         />
       </Container>
     )


### PR DESCRIPTION
Fix issue where clicking on a search result on mobile directs pagenotfound. Update the onClick to `onClick={() => navigate(`${GET_THE_APP}/${show.id}`)}`